### PR TITLE
Add rule for import ordering

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,6 +35,12 @@ module.exports = exports = {
         'import/first': DISABLED,
         'import/no-named-as-default': DISABLED,
         'import/prefer-default-export': DISABLED,
+        'import/order': [ERROR, 'always', {
+            'groups': [
+                'builtin', 'external', 'internal', 'parent', 'sibling', 'index'
+            ],
+            'newlines-between': 'always'
+        }],
         'indent': [ERROR, 4, {
             SwitchCase: WARN,
             MemberExpression: WARN,


### PR DESCRIPTION
Suggestion to add a new rule to enforce import order, like this:

```
// global imports
import React from 'react'

// parent imports
import A from '../../components/A'
import B from '../../components/B'

// imports from same directory
import C from './C'
import D from './D'
```

Newline is needed between groups. Types can't be enforced but we can maybe leave them as lasts of their groups as convention.