### PR TITLE
ts: permit then(thenCb, rejectCb) promise handling

### DIFF
--- a/ts/.eslintrc.js
+++ b/ts/.eslintrc.js
@@ -35,6 +35,9 @@ module.exports = exports = {
         'quote-props': DISABLED,
         'object-curly-newline': DISABLED,
         'promise/no-callback-in-promise': DISABLED,
+        'promise/catch-or-return': ["error", {
+            "allowThen": true
+        }],
         '@typescript-eslint/no-unused-vars': [ERROR, { 'argsIgnorePattern': '^_' }],
         '@typescript-eslint/no-explicit-any': DISABLED,
         '@typescript-eslint/no-empty-function': DISABLED,

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1218,6 +1218,12 @@
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
     },
+    "typescript": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "dev": true
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",

--- a/ts/package.json
+++ b/ts/package.json
@@ -4,7 +4,7 @@
   "description": "eslint-config standard to be used in Streamr's TypeScript projects",
   "main": "index.js",
   "scripts": {
-    "print-config": "eslint --print-config .eslintrc.js"
+    "test": "eslint --print-config .eslintrc.js"
   },
   "keywords": [
     "eslint",
@@ -13,10 +13,11 @@
   "author": "Streamr Network AG",
   "license": "MIT",
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^4.22.1",
+    "@typescript-eslint/parser": "^4.22.1",
     "eslint": "^7.25.0",
     "eslint-plugin-promise": "^5.1.0",
-    "@typescript-eslint/eslint-plugin": "^4.22.1",
-    "@typescript-eslint/parser": "^4.22.1"
+    "typescript": "^4.2.4"
   },
   "peerDependencies": {
     "eslint": "^7.25.0",


### PR DESCRIPTION
By default [eslint-plugin-promise](https://github.com/xjamundx/eslint-plugin-promise/blob/development/docs/rules/catch-or-return.md) enforces that a `catch` must always follow a `then`. Add an exception so that when doing `then(successFn, errorFn)`  a `catch` is not required to be followed.