### PR TITLE
Allow console.info

### DIFF
--- a/node.js/.eslintrc.js
+++ b/node.js/.eslintrc.js
@@ -32,7 +32,7 @@ module.exports = exports = {
             ObjectExpression: WARN,
         }],
         'max-len': [ERROR, { code: 120 }],
-        'no-console': [WARN, { allow: ['warn', 'error'] }],
+        'no-console': [WARN, { allow: ['warn', 'error', 'info'] }],
         'no-empty-function': WARN,
         'no-debugger': WARN,
         'no-multiple-empty-lines': [ERROR, {

--- a/react/.eslintrc.js
+++ b/react/.eslintrc.js
@@ -49,7 +49,7 @@ module.exports = exports = {
         'jsx-a11y/label-has-for': DISABLED,
         'jsx-a11y/label-has-associated-control': ERROR,
         'max-len': [ERROR, { code: 150 }],
-        'no-console': [WARN, { allow: ['warn', 'error'] }],
+        'no-console': [WARN, { allow: ['warn', 'error', 'info'] }],
         'no-debugger': WARN,
         'no-multiple-empty-lines': [ERROR, {
             max: 1,

--- a/ts/.eslintrc.js
+++ b/ts/.eslintrc.js
@@ -14,7 +14,7 @@ module.exports = exports = {
         'indent': [ERROR, 4, {
             "SwitchCase": 1
         }],
-        'no-console': [WARN, { allow: ['warn', 'error'] }],
+        'no-console': [WARN, { allow: ['warn', 'error', 'info'] }],
         'no-debugger': WARN,
         'no-multiple-empty-lines': [ERROR, {
             max: 1,


### PR DESCRIPTION
Saves having to add eslint-disable annotations. 
console.log/trace/debug will still get flagged.

Will squash+merge so don't worry about commit messages in PR.